### PR TITLE
refactor: additional Nuxt review findings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,8 @@ jobs:
         run: pnpm generate
 
       - name: Deploy via FTP
+        # Full sync: deletes remote files not present in local build to ensure
+        # a clean deployment matching the generated output exactly.
         uses: SamKirkland/FTP-Deploy-Action@v4.3.6
         with:
           server: ${{ secrets.HOST }}

--- a/app/components/landing/LabsTeaser.vue
+++ b/app/components/landing/LabsTeaser.vue
@@ -2,14 +2,7 @@
 type LabsSection = {
   title: string
   description: string
-  link: {
-    label: string
-    icon?: string
-    to?: string
-    color?: 'primary' | 'neutral' | 'success' | 'warning' | 'error' | 'info'
-    variant?: 'solid' | 'outline' | 'subtle' | 'soft' | 'ghost' | 'link'
-    target?: '_blank' | '_self'
-  }
+  link: ContentButton
 }
 
 defineProps<{

--- a/app/components/landing/SpeakingTeaser.vue
+++ b/app/components/landing/SpeakingTeaser.vue
@@ -3,14 +3,7 @@ type SpeakingSection = {
   title: string
   description: string
   note?: string
-  link: {
-    label: string
-    icon?: string
-    to?: string
-    color?: 'primary' | 'neutral' | 'success' | 'warning' | 'error' | 'info'
-    variant?: 'solid' | 'outline' | 'subtle' | 'soft' | 'ghost' | 'link'
-    target?: '_blank' | '_self'
-  }
+  link: ContentButton
 }
 
 defineProps<{

--- a/app/composables/usePageSeo.ts
+++ b/app/composables/usePageSeo.ts
@@ -8,8 +8,8 @@ type SeoInput = {
 }
 
 export function usePageSeo(page: SeoInput) {
-  const title = page.seo?.title || page.title
-  const description = page.seo?.description || page.description
+  const title = page.seo?.title ?? page.title
+  const description = page.seo?.description ?? page.description
 
   useSeoMeta({
     title,

--- a/app/composables/usePageSeo.ts
+++ b/app/composables/usePageSeo.ts
@@ -1,0 +1,20 @@
+type SeoInput = {
+  title?: string
+  description?: string
+  seo?: {
+    title?: string
+    description?: string
+  } | null
+}
+
+export function usePageSeo(page: SeoInput) {
+  const title = page.seo?.title || page.title
+  const description = page.seo?.description || page.description
+
+  useSeoMeta({
+    title,
+    ogTitle: title,
+    description,
+    ogDescription: description
+  })
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -23,12 +23,9 @@ if (!page.value) {
   })
 }
 
-useSeoMeta({
-  title: page.value?.seo.title || page.value?.title,
-  ogTitle: page.value?.seo.title || page.value?.title,
-  description: page.value?.seo.description || page.value?.description,
-  ogDescription: page.value?.seo.description || page.value?.description
-})
+usePageSeo(page.value)
+
+defineOgImage()
 </script>
 
 <template>

--- a/app/pages/labs/[slug].vue
+++ b/app/pages/labs/[slug].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { formatLabDate, labStatusIconMap, labStatusMap } from '../../utils/labs'
+
 const route = useRoute()
 const slug = Array.isArray(route.params.slug) ? route.params.slug[0] : route.params.slug
 

--- a/app/pages/labs/[slug].vue
+++ b/app/pages/labs/[slug].vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
+import { formatLabDate, labStatusIconMap, labStatusMap } from '../../utils/labs'
 const route = useRoute()
 const slug = Array.isArray(route.params.slug) ? route.params.slug[0] : route.params.slug
 
-const { data: lab } = await useAsyncData(`lab-${slug}`, async () => {
-  const entries = await queryCollection('labs').all()
-  const sortedEntries = sortLabs(entries)
-
-  return sortedEntries.find(entry => getLabSlug(entry) === slug) ?? null
+const { data: lab } = await useAsyncData(`lab-${slug}`, () => {
+  return queryCollection('labs').where('stem', '=', `labs/${slug}`).first()
 })
 
 if (!lab.value) {
@@ -17,12 +15,9 @@ if (!lab.value) {
   })
 }
 
-useSeoMeta({
-  title: lab.value.title,
-  ogTitle: lab.value.title,
-  description: lab.value.description,
-  ogDescription: lab.value.description
-})
+usePageSeo(lab.value)
+
+defineOgImage()
 
 const formattedDate = computed(() => formatLabDate(lab.value!.date))
 const hasImage = computed(() => Boolean(lab.value?.image))

--- a/app/pages/labs/index.vue
+++ b/app/pages/labs/index.vue
@@ -17,12 +17,9 @@ if (!page.value) {
   })
 }
 
-useSeoMeta({
-  title: page.value?.seo?.title || page.value?.title,
-  ogTitle: page.value?.seo?.title || page.value?.title,
-  description: page.value?.seo?.description || page.value?.description,
-  ogDescription: page.value?.seo?.description || page.value?.description
-})
+usePageSeo(page.value)
+
+defineOgImage()
 </script>
 
 <template>

--- a/app/pages/speaking/[slug].vue
+++ b/app/pages/speaking/[slug].vue
@@ -19,7 +19,7 @@ if (!talk.value) {
 
 usePageSeo({
   title: talk.value.title,
-  description: talk.value.summary || talk.value.description
+  description: talk.value.summary ?? talk.value.description
 })
 
 defineOgImage()

--- a/app/pages/speaking/[slug].vue
+++ b/app/pages/speaking/[slug].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { resolveTalkEntry, type ResolvedTalkResource } from '../../utils/speaking'
+
 const route = useRoute()
 const slug = Array.isArray(route.params.slug) ? route.params.slug[0] : route.params.slug
 

--- a/app/pages/speaking/[slug].vue
+++ b/app/pages/speaking/[slug].vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
+import { resolveTalkEntry, type ResolvedTalkResource } from '../../utils/speaking'
 const route = useRoute()
 const slug = Array.isArray(route.params.slug) ? route.params.slug[0] : route.params.slug
 
 const { data: talk } = await useAsyncData(`talk-${slug}`, async () => {
-  const entries = await queryCollection('talks').all()
-  const sortedEntries = sortTalks(entries)
-  const entry = sortedEntries.find(entry => getTalkSlug(entry) === slug) ?? null
+  const entry = await queryCollection('talks').where('stem', '=', `speaking/${slug}`).first()
 
   return entry ? resolveTalkEntry(entry) : null
 })
@@ -18,12 +17,12 @@ if (!talk.value) {
   })
 }
 
-useSeoMeta({
+usePageSeo({
   title: talk.value.title,
-  ogTitle: talk.value.title,
-  description: talk.value.summary || talk.value.description,
-  ogDescription: talk.value.summary || talk.value.description
+  description: talk.value.summary || talk.value.description
 })
+
+defineOgImage()
 
 const organizerSubtitle = computed(() => {
   if (!talk.value?.organizerTitle) {

--- a/app/pages/speaking/index.vue
+++ b/app/pages/speaking/index.vue
@@ -17,12 +17,9 @@ if (!page.value) {
   })
 }
 
-useSeoMeta({
-  title: page.value?.seo?.title || page.value?.title,
-  ogTitle: page.value?.seo?.title || page.value?.title,
-  description: page.value?.seo?.description || page.value?.description,
-  ogDescription: page.value?.seo?.description || page.value?.description
-})
+usePageSeo(page.value)
+
+defineOgImage()
 </script>
 
 <template>

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -1,0 +1,8 @@
+export type ContentButton = {
+  label: string
+  icon?: string
+  to?: string
+  color?: 'primary' | 'neutral' | 'success' | 'warning' | 'error' | 'info'
+  variant?: 'solid' | 'outline' | 'subtle' | 'soft' | 'ghost' | 'link'
+  target?: '_blank' | '_self'
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,4 @@
 // @ts-check
 import withNuxt from './.nuxt/eslint.config.mjs'
 
-export default withNuxt({
-  rules: {
-    '@typescript-eslint/no-explicit-any': 'off'
-  }
-})
+export default withNuxt()

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,7 +5,6 @@ export default defineNuxtConfig({
     '@nuxt/image',
     '@nuxt/ui',
     '@nuxt/content',
-    '@vueuse/nuxt',
     'nuxt-og-image',
     'motion-v/nuxt'
   ],
@@ -27,7 +26,7 @@ export default defineNuxtConfig({
     }
   },
 
-  compatibilityDate: '2024-11-01',
+  compatibilityDate: '2025-03-01',
 
   nitro: {
     prerender: {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@nuxt/content": "^3.12.0",
     "@nuxt/image": "^2.0.0",
     "@nuxt/ui": "^4.6.0",
-    "@vueuse/nuxt": "^14.2.1",
     "better-sqlite3": "^12.6.2",
     "motion-v": "^2.2.0",
     "nuxt": "^4.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,9 +28,6 @@ importers:
       '@nuxt/ui':
         specifier: ^4.6.0
         version: 4.6.0(@nuxt/content@3.12.0(better-sqlite3@12.6.2)(magicast@0.5.2))(@tiptap/extensions@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))(@tiptap/y-tiptap@3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.7)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.6.2))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))(vue-router@5.0.4(@vue/compiler-sfc@3.5.30)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))(yjs@13.6.29)(zod@3.25.76)
-      '@vueuse/nuxt':
-        specifier: ^14.2.1
-        version: 14.2.1(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.3.5)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.6.2))(eslint@10.0.3(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -2708,12 +2705,6 @@ packages:
 
   '@vueuse/metadata@14.2.1':
     resolution: {integrity: sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==}
-
-  '@vueuse/nuxt@14.2.1':
-    resolution: {integrity: sha512-DHgFMUpyH98M1YM9pbnRjFXMAMKEsHntJeOp8rOXs8QN2cvJBzEZ+TTWIBSPESNFOEwM02RA6BDsaTL35OK4Mw==}
-    peerDependencies:
-      nuxt: ^3.0.0 || ^4.0.0-0
-      vue: ^3.5.0
 
   '@vueuse/shared@10.11.1':
     resolution: {integrity: sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==}
@@ -9239,17 +9230,6 @@ snapshots:
   '@vueuse/metadata@10.11.1': {}
 
   '@vueuse/metadata@14.2.1': {}
-
-  '@vueuse/nuxt@14.2.1(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.3.5)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.6.2))(eslint@10.0.3(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))':
-    dependencies:
-      '@nuxt/kit': 4.3.1(magicast@0.5.2)
-      '@vueuse/core': 14.2.1(vue@3.5.30(typescript@5.9.3))
-      '@vueuse/metadata': 14.2.1
-      local-pkg: 1.1.2
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.3.5)(@vue/compiler-sfc@3.5.30)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.6.2))(eslint@10.0.3(jiti@2.6.1))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.0))(rollup@4.60.0)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))(vue-tsc@3.2.5(typescript@5.9.3))(yaml@2.8.3)
-      vue: 3.5.30(typescript@5.9.3)
-    transitivePeerDependencies:
-      - magicast
 
   '@vueuse/shared@10.11.1(vue@3.5.30(typescript@5.9.3))':
     dependencies:


### PR DESCRIPTION
## Summary

Addresses the additional observations from the initial code review (#14). These are deeper structural improvements to align with Nuxt best practices.

### Changes

- **Remove unused `@vueuse/nuxt`** — Module was registered but no VueUse composables are used in the codebase. `useColorMode` is already provided by Nuxt UI.
- **Update `compatibilityDate`** — Bumped from `2024-11-01` to `2025-03-01` to match Nuxt 4.
- **Re-enable `@typescript-eslint/no-explicit-any`** — Was globally disabled but no `any` usages exist in the codebase. Removed the override to keep the stricter default.
- **Extract `usePageSeo` composable** — Replaces 5 duplicated `useSeoMeta({ title, ogTitle, description, ogDescription })` blocks across all pages with a single composable in `app/composables/usePageSeo.ts`.
- **Extract shared `ContentButton` type** — `LabsTeaser` and `SpeakingTeaser` both had identical 7-line inline button types. Moved to `app/utils/types.ts` and referenced via Nuxt auto-import.
- **Optimize `[slug]` page queries** — Both `labs/[slug].vue` and `speaking/[slug].vue` were fetching ALL entries, sorting, then filtering by slug. Now they query directly by `stem` which is more efficient.
- **Add `defineOgImage()`** — The `nuxt-og-image` module was installed but never activated. Added `defineOgImage()` to all 5 pages so OG images are generated from page meta.
- **Document deploy workflow** — Added a comment explaining why `dangerous-clean-slate: true` is used in the FTP deploy step.

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm run typecheck` passes
- [x] Verify all pages still render correctly
- [x] Verify OG images are generated at `/__og-image__/` routes
- [x] Verify content queries by stem resolve correctly for all lab and talk detail pages

https://claude.ai/code/session_01D9Js2socgpErtmsWh88fMj