### PR TITLE
FTP deploy: remove clean slate, only trigger on site changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'app/**'
+      - 'content/**'
+      - 'public/**'
+      - 'nuxt.config.ts'
+      - 'content.config.ts'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'tsconfig.json'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,6 @@ jobs:
         run: pnpm generate
 
       - name: Deploy via FTP
-        # Full sync: deletes remote files not present in local build to ensure
-        # a clean deployment matching the generated output exactly.
         uses: SamKirkland/FTP-Deploy-Action@v4.3.6
         with:
           server: ${{ secrets.HOST }}
@@ -41,4 +39,3 @@ jobs:
           password: ${{ secrets.PASSWORD }}
           local-dir: ./.output/public/
           server-dir: ./httpdocs/
-          dangerous-clean-slate: true


### PR DESCRIPTION
## Summary

- Remove `dangerous-clean-slate` from FTP deploy — only upload changed files instead of wiping and re-uploading everything
- Add path filters so the workflow only triggers on changes that affect the generated site (`app/`, `content/`, `public/`, config/dep files), not on README or other non-site files

https://claude.ai/code/session_01EqMFsFWqQXgKfR4T6YA6Ss