### PR TITLE
Add Rheinwerk Spotlight talk and workshop entries

### DIFF
--- a/content/speaking/spec-code-verify.yml
+++ b/content/speaking/spec-code-verify.yml
@@ -1,0 +1,23 @@
+title: "Spec, Code, Verify: Building Your Own AI Development Workflows"
+summary: A hands-on full-day workshop where you build a Spec-Driven Development workflow from scratch — structured specs, task patterns, quality gates, and end-to-end verification resulting in an agent pipeline from ticket to reviewable result.
+description: >-
+  Ad-hoc prompting gets you started, but it doesn't scale. In this full-day
+  workshop you build a Spec-Driven Development workflow piece by piece — from
+  scratch, hands-on, with your own tools. You'll learn how to write structured
+  specs that an agent can actually follow, how to define reusable task
+  patterns, where to add quality gates, and how to close the loop with
+  automated verification. By the end of the day you'll have a working pipeline:
+  feed it a ticket, get back a spec, an implementation, a verification result,
+  and a reviewable output — all within defined quality standards. Bring your
+  laptop and expect to write real code.
+event: "Rheinwerk Spotlight »Coding mit KI«"
+location: Online
+topic: Spec-Driven Development
+date: 2026-06-24
+dateLabel: "June 24, 2026"
+time: "09:30"
+duration: Full day (9:30–17:00 incl. lunch)
+format: Workshop
+language: German
+eventUrl: https://www.rheinwerk-verlag.de/konferenzen/coding-mit-ki/
+placeholder: true

--- a/content/speaking/spec-driven-development-in-practice.yml
+++ b/content/speaking/spec-driven-development-in-practice.yml
@@ -1,0 +1,22 @@
+title: "Spec-Driven Development in Practice: From Prompt to Process"
+summary: From ad-hoc prompting to a structured Spec-Driven Development workflow — a practical look at how to make AI-assisted coding reliable and repeatable in real project work.
+description: >-
+  Most developers start using AI coding tools the same way: throw a prompt at
+  it and hope for the best. That works — until it doesn't. This talk walks
+  through the journey from loose, ad-hoc prompting to a structured
+  Spec-Driven Development workflow. What makes a spec actually useful? How do
+  you define task patterns that an agent can follow reliably? Where do quality
+  gates and verification fit in? And what does the process look like once all
+  the pieces are in place? Honest lessons from real project work — including
+  what didn't work and what we'd do differently.
+event: "Rheinwerk Spotlight »Coding mit KI«"
+location: Online
+topic: Spec-Driven Development
+date: 2026-06-23
+dateLabel: "June 23, 2026 · 12:00"
+time: "12:00"
+duration: 45 min
+format: Talk
+language: German
+eventUrl: https://www.rheinwerk-verlag.de/konferenzen/coding-mit-ki/
+placeholder: true


### PR DESCRIPTION
## Summary

- Adds talk entry: **Spec-Driven Development in Practice: From Prompt to Process** (June 23, 2026 · 12:00, 45 min)
- Adds workshop entry: **Spec, Code, Verify: Building Your Own AI Development Workflows** (June 24, 2026, full day)
- Both at Rheinwerk Spotlight »Coding mit KI« (online), marked as `placeholder: true`

## Test plan

- [ ] Navigate to `/speaking` and confirm both entries appear, sorted above the March 2026 Hamburg talk
- [ ] Click through to each detail page and verify all fields render correctly
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes

https://claude.ai/code/session_01YWYZmY9dh8cVBhk961spD9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWYZmY9dh8cVBhk961spD9)_