### PR TITLE
Add per-PR preview deployments to preview.fmeyer.dev

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -41,22 +41,14 @@ jobs:
           NUXT_PUBLIC_SITE_URL: https://preview.fmeyer.dev/pr-${{ github.event.pull_request.number }}
         run: pnpm generate
 
-      - name: Install lftp
-        run: sudo apt-get update && sudo apt-get install -y lftp
-
-      - name: Deploy via SFTP
-        env:
-          SFTP_HOST: ${{ secrets.HOST }}
-          SFTP_USER: ${{ secrets.SFTP_PREVIEW_USER }}
-          SFTP_PASS: ${{ secrets.SFTP_PREVIEW_PASSWORD }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          lftp -u "$SFTP_USER,$SFTP_PASS" "sftp://$SFTP_HOST" <<EOF
-          set sftp:auto-confirm yes
-          mkdir -p -f ./previews/pr-${PR_NUMBER}
-          mirror -R --delete --verbose ./.output/public/ ./previews/pr-${PR_NUMBER}
-          bye
-          EOF
+      - name: Deploy via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
+        with:
+          server: ${{ secrets.HOST }}
+          username: ${{ secrets.SFTP_PREVIEW_USER }}
+          password: ${{ secrets.SFTP_PREVIEW_PASSWORD }}
+          local-dir: ./.output/public/
+          server-dir: ./previews/pr-${{ github.event.pull_request.number }}/
 
       - name: Comment preview URL
         if: github.event.action == 'opened' || github.event.action == 'reopened'
@@ -80,13 +72,12 @@ jobs:
 
       - name: Delete preview directory
         env:
-          SFTP_HOST: ${{ secrets.HOST }}
-          SFTP_USER: ${{ secrets.SFTP_PREVIEW_USER }}
-          SFTP_PASS: ${{ secrets.SFTP_PREVIEW_PASSWORD }}
+          FTP_HOST: ${{ secrets.HOST }}
+          FTP_USER: ${{ secrets.SFTP_PREVIEW_USER }}
+          FTP_PASS: ${{ secrets.SFTP_PREVIEW_PASSWORD }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          lftp -u "$SFTP_USER,$SFTP_PASS" "sftp://$SFTP_HOST" <<EOF
-          set sftp:auto-confirm yes
+          lftp -u "$FTP_USER,$FTP_PASS" "$FTP_HOST" <<EOF
           set cmd:fail-exit no
           rm -r ./previews/pr-${PR_NUMBER}
           bye

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -47,6 +47,7 @@ jobs:
           server: ${{ secrets.HOST }}
           username: ${{ secrets.SFTP_PREVIEW_USER }}
           password: ${{ secrets.SFTP_PREVIEW_PASSWORD }}
+          protocol: ftps
           local-dir: ./.output/public/
           server-dir: ./previews/pr-${{ github.event.pull_request.number }}/
 
@@ -78,6 +79,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           lftp -u "$FTP_USER,$FTP_PASS" "$FTP_HOST" <<EOF
+          set ftp:ssl-force true
+          set ftp:ssl-protect-data true
           set cmd:fail-exit no
           rm -r ./previews/pr-${PR_NUMBER}
           bye

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -41,14 +41,22 @@ jobs:
           NUXT_PUBLIC_SITE_URL: https://preview.fmeyer.dev/pr-${{ github.event.pull_request.number }}
         run: pnpm generate
 
-      - name: Deploy via FTP
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
-        with:
-          server: ${{ secrets.HOST }}
-          username: ${{ secrets.USERNAME }}
-          password: ${{ secrets.PASSWORD }}
-          local-dir: ./.output/public/
-          server-dir: ./previews/pr-${{ github.event.pull_request.number }}/
+      - name: Install lftp
+        run: sudo apt-get update && sudo apt-get install -y lftp
+
+      - name: Deploy via SFTP
+        env:
+          SFTP_HOST: ${{ secrets.HOST }}
+          SFTP_USER: ${{ secrets.SFTP_PREVIEW_USER }}
+          SFTP_PASS: ${{ secrets.SFTP_PREVIEW_PASSWORD }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          lftp -u "$SFTP_USER,$SFTP_PASS" "sftp://$SFTP_HOST" <<EOF
+          set sftp:auto-confirm yes
+          mkdir -p -f ./previews/pr-${PR_NUMBER}
+          mirror -R --delete --verbose ./.output/public/ ./previews/pr-${PR_NUMBER}
+          bye
+          EOF
 
       - name: Comment preview URL
         if: github.event.action == 'opened' || github.event.action == 'reopened'
@@ -72,12 +80,13 @@ jobs:
 
       - name: Delete preview directory
         env:
-          FTP_HOST: ${{ secrets.HOST }}
-          FTP_USER: ${{ secrets.USERNAME }}
-          FTP_PASS: ${{ secrets.PASSWORD }}
+          SFTP_HOST: ${{ secrets.HOST }}
+          SFTP_USER: ${{ secrets.SFTP_PREVIEW_USER }}
+          SFTP_PASS: ${{ secrets.SFTP_PREVIEW_PASSWORD }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          lftp -u "$FTP_USER,$FTP_PASS" "$FTP_HOST" <<EOF
+          lftp -u "$SFTP_USER,$SFTP_PASS" "sftp://$SFTP_HOST" <<EOF
+          set sftp:auto-confirm yes
           set cmd:fail-exit no
           rm -r ./previews/pr-${PR_NUMBER}
           bye

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,84 @@
+name: deploy-preview
+
+# preview.fmeyer.dev must be configured in the hosting panel to serve from
+# ./previews/. Each PR is deployed to ./previews/pr-<n>/ and removed on close.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy:
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    concurrency:
+      group: preview-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate static site
+        env:
+          NUXT_APP_BASE_URL: /pr-${{ github.event.pull_request.number }}/
+          NUXT_PUBLIC_SITE_URL: https://preview.fmeyer.dev/pr-${{ github.event.pull_request.number }}
+        run: pnpm generate
+
+      - name: Deploy via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
+        with:
+          server: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          local-dir: ./.output/public/
+          server-dir: ./previews/pr-${{ github.event.pull_request.number }}/
+
+      - name: Comment preview URL
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --body "Preview: https://preview.fmeyer.dev/pr-${PR_NUMBER}/"
+
+  cleanup:
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    concurrency:
+      group: preview-${{ github.event.pull_request.number }}
+
+    steps:
+      - name: Install lftp
+        run: sudo apt-get update && sudo apt-get install -y lftp
+
+      - name: Delete preview directory
+        env:
+          FTP_HOST: ${{ secrets.HOST }}
+          FTP_USER: ${{ secrets.USERNAME }}
+          FTP_PASS: ${{ secrets.PASSWORD }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          lftp -u "$FTP_USER,$FTP_PASS" "$FTP_HOST" <<EOF
+          set cmd:fail-exit no
+          rm -r ./previews/pr-${PR_NUMBER}
+          bye
+          EOF

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -10,10 +10,32 @@ on:
 permissions:
   contents: read
   deployments: write
+  pull-requests: read
 
 jobs:
-  deploy:
+  changes:
     if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      site: ${{ steps.filter.outputs.site }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            site:
+              - 'app/**'
+              - 'content/**'
+              - 'public/**'
+              - 'nuxt.config.ts'
+              - 'content.config.ts'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'tsconfig.json'
+
+  deploy:
+    needs: changes
+    if: needs.changes.outputs.site == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: preview-${{ github.event.pull_request.number }}
@@ -48,6 +70,7 @@ jobs:
         env:
           NUXT_APP_BASE_URL: /pr-${{ github.event.pull_request.number }}/
           NUXT_PUBLIC_SITE_URL: https://preview.fmeyer.dev/pr-${{ github.event.pull_request.number }}
+          NUXT_PUBLIC_NOINDEX: 'true'
         run: pnpm generate
 
       - name: Deploy via FTP

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  deployments: write
 
 jobs:
   deploy:
@@ -22,6 +22,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Start deployment
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: preview-pr-${{ github.event.pull_request.number }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -51,15 +60,16 @@ jobs:
           local-dir: ./.output/public/
           server-dir: ./previews/pr-${{ github.event.pull_request.number }}/
 
-      - name: Comment preview URL
-        if: github.event.action == 'opened' || github.event.action == 'reopened'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh pr comment "$PR_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --body "Preview: https://preview.fmeyer.dev/pr-${PR_NUMBER}/"
+      - name: Finish deployment
+        if: always()
+        uses: bobheadxi/deployments@v1
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env: ${{ steps.deployment.outputs.env }}
+          env_url: https://preview.fmeyer.dev/pr-${{ github.event.pull_request.number }}/
 
   cleanup:
     if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
@@ -85,3 +95,11 @@ jobs:
           rm -r ./previews/pr-${PR_NUMBER}
           bye
           EOF
+
+      - name: Deactivate deployment
+        uses: bobheadxi/deployments@v1
+        with:
+          step: deactivate-env
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: preview-pr-${{ github.event.pull_request.number }}
+          desc: Preview removed

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,9 +21,22 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
 
+    permissions:
+      contents: read
+      deployments: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Start deployment
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: production
+          ref: ${{ github.sha }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -49,3 +62,14 @@ jobs:
           protocol: ftps
           local-dir: ./.output/public/
           server-dir: ./httpdocs/
+
+      - name: Finish deployment
+        if: always()
+        uses: bobheadxi/deployments@v1
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env: ${{ steps.deployment.outputs.env }}
+          env_url: https://fmeyer.dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,5 +46,6 @@ jobs:
           server: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           password: ${{ secrets.PASSWORD }}
+          protocol: ftps
           local-dir: ./.output/public/
           server-dir: ./httpdocs/

--- a/app/app.vue
+++ b/app/app.vue
@@ -12,7 +12,8 @@ useHead({
   meta: [
     { charset: 'utf-8' },
     { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-    { key: 'theme-color', name: 'theme-color', content: color }
+    { key: 'theme-color', name: 'theme-color', content: color },
+    ...(runtimeConfig.public.noindex ? [{ name: 'robots', content: 'noindex, nofollow' }] : [])
   ],
   link: [
     { rel: 'icon', href: '/favicon.ico' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,7 +22,8 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     public: {
-      siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'https://fmeyer.dev'
+      siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'https://fmeyer.dev',
+      noindex: process.env.NUXT_PUBLIC_NOINDEX === 'true'
     }
   },
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-preview.yml` that builds each PR with `NUXT_APP_BASE_URL=/pr-<n>/` and `NUXT_PUBLIC_SITE_URL=https://preview.fmeyer.dev/pr-<n>` and uploads to `./previews/pr-<n>/` over SFTP using `lftp`.
- Comments the preview URL on the PR when opened/reopened.
- On PR close, removes `./previews/pr-<n>/` so old previews don't accumulate.
- Skips fork PRs to avoid leaking SFTP credentials.

## Setup

- `preview.fmeyer.dev` configured in the hosting panel to serve from `./previews/`.
- Repo secrets: reuses existing `HOST`, plus new `SFTP_PREVIEW_USER` and `SFTP_PREVIEW_PASSWORD` scoped to the previews directory.

## Test plan

- [ ] Open a PR and confirm the workflow runs, deploys, and comments the preview URL.
- [ ] Visit `https://preview.fmeyer.dev/pr-<n>/` and verify assets, links, and OG image resolve under the base path.
- [ ] Push another commit and confirm the preview updates.
- [ ] Close the PR and confirm the directory is removed from the host.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr93nPWcHuMLQEht4r583M)_