### PR TITLE
Delete GitHub environment on PR close

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -8,6 +8,7 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 permissions:
+  administration: write
   contents: read
   deployments: write
   pull-requests: read
@@ -119,10 +120,9 @@ jobs:
           bye
           EOF
 
-      - name: Deactivate deployment
+      - name: Delete environment
         uses: bobheadxi/deployments@v1
         with:
-          step: deactivate-env
+          step: delete-env
           token: ${{ secrets.GITHUB_TOKEN }}
           env: preview-pr-${{ github.event.pull_request.number }}
-          desc: Preview removed


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Switches cleanup job from `deactivate-env` to `delete-env` so the GitHub environment entity is fully removed when a PR closes, not just marked inactive
- Adds `administration: write` permission required by the environment deletion API

Closes #28

https://claude.ai/code/session_019fzi9YyX9VkBmp341XJ7h1
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019fzi9YyX9VkBmp341XJ7h1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dinooo13/codesmith/fmeyer.dev/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->