### PR TITLE
Remove Google Search Console meta-tag verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,3 @@
 # Public URL, used for OG Image when running nuxt generate
 NUXT_PUBLIC_SITE_URL=https://fmeyer.dev
 
-# Google Search Console verification token (from the meta-tag method).
-# Leave empty to omit the meta tag entirely.
-NUXT_PUBLIC_GOOGLE_SITE_VERIFICATION=

--- a/app/app.vue
+++ b/app/app.vue
@@ -14,11 +14,6 @@ const profileImageUrl = new URL(
   runtimeConfig.public.siteUrl
 ).toString()
 
-const verificationMeta = computed(() => {
-  const token = runtimeConfig.public.googleSiteVerification
-  return token ? [{ name: 'google-site-verification', content: token }] : []
-})
-
 useHead({
   meta: [
     { charset: 'utf-8' },
@@ -30,8 +25,7 @@ useHead({
       content: runtimeConfig.public.noindex
         ? 'noindex, nofollow'
         : 'index, follow, max-image-preview:large'
-    },
-    ...verificationMeta.value
+    }
   ],
   link: [
     { rel: 'icon', href: `${baseURL}favicon.ico` },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -21,7 +21,6 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'https://fmeyer.dev',
-      googleSiteVerification: process.env.NUXT_PUBLIC_GOOGLE_SITE_VERIFICATION || '',
       noindex: process.env.NUXT_PUBLIC_NOINDEX === 'true'
     }
   },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Remove `googleSiteVerification` from `runtimeConfig.public` in `nuxt.config.ts`
- Remove `verificationMeta` computed and its spread in `useHead` from `app/app.vue`
- Remove `NUXT_PUBLIC_GOOGLE_SITE_VERIFICATION` env var from `.env.example`

Verification is now handled via DNS, so the meta-tag approach and all supporting code are no longer needed.

Closes #29

https://claude.ai/code/session_01HXD52uBhadASqr8mSCAQqb
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXD52uBhadASqr8mSCAQqb)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dinooo13/codesmith/fmeyer.dev/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->