### PR TITLE
fix: correct heading order on /labs and /speaking (a11y)

### DIFF
--- a/app/components/LabCard.vue
+++ b/app/components/LabCard.vue
@@ -19,9 +19,9 @@ defineProps<{
             class="size-5 shrink-0 text-black dark:text-white"
           />
 
-          <h3 class="min-w-0 text-lg font-semibold text-highlighted">
+          <h2 class="min-w-0 text-lg font-semibold text-highlighted">
             {{ lab.title }}
-          </h3>
+          </h2>
         </div>
 
         <UBadge

--- a/app/components/landing/SpeakingTeaser.vue
+++ b/app/components/landing/SpeakingTeaser.vue
@@ -39,6 +39,7 @@ defineProps<{
         :talk="talk"
         variant="featured"
         :show-summary="true"
+        heading-level="h3"
         :primary-action="{
           label: 'View details',
           to: getTalkPath(talk)

--- a/app/components/talks/TalkPreviewCard.vue
+++ b/app/components/talks/TalkPreviewCard.vue
@@ -10,10 +10,12 @@ const props = withDefaults(defineProps<{
   showSummary?: boolean
   showMeta?: boolean
   primaryAction?: PreviewAction
+  headingLevel?: 'h2' | 'h3'
 }>(), {
   variant: 'list',
   showSummary: true,
-  showMeta: false
+  showMeta: false,
+  headingLevel: 'h2'
 })
 
 const badgeLabel = computed(() => props.talk?.placeholder ? 'Upcoming' : 'Talk')
@@ -64,12 +66,13 @@ const subtitle = computed(() => {
           />
 
           <div class="space-y-2">
-            <h3
+            <component
+              :is="headingLevel"
               class="font-semibold text-highlighted"
               :class="variant === 'featured' ? 'text-xl sm:text-2xl' : 'text-2xl'"
             >
               {{ talk.title }}
-            </h3>
+            </component>
 
             <p
               v-if="subtitle"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `LabCard.vue`: changed `h3` → `h2` since it's the first heading after `h1` on the `/labs` listing page (no `h2` in between)
- `TalkPreviewCard.vue`: added a `headingLevel` prop (default `'h2'`) using `<component :is>` so the level is configurable per context
- `SpeakingTeaser.vue`: passes `heading-level="h3"` because the card sits inside a `UPageSection` with a title (`h2`), making `h3` correct there

## Test plan

- [ ] Visit `/labs` — Lighthouse a11y should no longer report a heading order violation
- [ ] Visit `/speaking` — same
- [ ] Visit `/` — heading hierarchy should remain valid (h1 → h2 section title → h3 card title in teasers)

Closes #36

https://claude.ai/code/session_01HdDhPm7H6kymqw9U7mnBzE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdDhPm7H6kymqw9U7mnBzE)_