### PR TITLE
Remove unnecessary administration permission from deploy preview workflow

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -8,7 +8,6 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 permissions:
-  administration: write
   contents: read
   deployments: write
   pull-requests: read


### PR DESCRIPTION
## Summary
Removed the `administration: write` permission from the deploy preview workflow permissions configuration, as it is not required for the workflow's operations.

## Key Changes
- Removed `administration: write` from the permissions block in `.github/workflows/deploy-preview.yml`
- Retained necessary permissions: `contents: read`, `deployments: write`, and `pull-requests: read`

## Details
The `administration: write` permission grants unnecessary elevated privileges to this workflow. The workflow only needs to read repository contents, manage deployments, and read pull request information to function correctly. This change follows the principle of least privilege by removing unused permissions.

https://claude.ai/code/session_01N9NMWtrmNAMNDmcxKHEeXQ